### PR TITLE
Unify Keras's cost function with the Estimator's

### DIFF
--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -103,7 +103,6 @@ def synthetic_input_fn(batch_size, height, width, num_channels, num_classes,
       maxval=num_classes - 1,
       dtype=tf.int32,
       name='synthetic_labels')
-  labels = tf.one_hot(labels, imagenet_main._NUM_CLASSES)
 
   dataset = tf.data.Dataset.from_tensors((inputs, labels)).repeat()
   dataset = dataset.prefetch(buffer_size=tf.contrib.data.AUTOTUNE)

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -153,7 +153,7 @@ def run_imagenet_with_keras(flags_obj):
   # in the graph.
   tf.keras.backend.set_learning_phase(True)
 
-  model.compile(loss=softmax_corss_entrophy,
+  model.compile(loss=softmax_corssentropy_with_logits,
                 optimizer=opt,
                 metrics=["accuracy"],
                 distribute=strategy)
@@ -186,8 +186,8 @@ def run_imagenet_with_keras(flags_obj):
                                      steps_per_epoch, samples_per_second))
 
 
-def softmax_corss_entrophy(y_true, y_pred):
-  """A cost function replicating tf's sparse_softmax_cross_entropy
+def softmax_corssentropy_with_logits(y_true, y_pred):
+  """A loss function replicating tf's sparse_softmax_cross_entropy
 
   Args:
     y_true: True labels. Tensor.

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -152,7 +152,7 @@ def run_imagenet_with_keras(flags_obj):
   # in the graph.
   tf.keras.backend.set_learning_phase(True)
 
-  model.compile(loss=softmax_corssentropy_with_logits,
+  model.compile(loss=softmax_crossentropy_with_logits,
                 optimizer=opt,
                 metrics=["accuracy"],
                 distribute=strategy)
@@ -185,7 +185,7 @@ def run_imagenet_with_keras(flags_obj):
                                      steps_per_epoch, samples_per_second))
 
 
-def softmax_corssentropy_with_logits(y_true, y_pred):
+def softmax_crossentropy_with_logits(y_true, y_pred):
   """A loss function replicating tf's sparse_softmax_cross_entropy
 
   Args:


### PR DESCRIPTION
This PR does not complete the task. 

TODO: In the Estimator, the loss function also include an L2 cost, which
is currently missing from Keras's.

See: https://github.com/tfboyd/models/blob/resnet_perf_tweaks/official/resnet/resnet_run_loop.py#L316