### PR TITLE
Separate train an eval for estimator

### DIFF
--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -546,7 +546,7 @@ def resnet_main(
       classifier.train(input_fn=lambda: input_fn_train(num_train_epochs),
                        hooks=train_hooks, max_steps=flags_obj.max_train_steps)
 
-    if flags_obj.do_eval:
+    if not flags_obj.skip_eval:
       tf.logging.info('Starting to evaluate.')
 
       # flags_obj.max_train_steps is generally associated with testing and
@@ -595,9 +595,8 @@ def define_resnet_flags(resnet_size_choices=None):
           'If not None initialize all the network except the final layer with '
           'these values'))
   flags.DEFINE_boolean(
-      name='do_eval', default=False,
-      help=flags_core.help_wrap('Do evalueation step only when this flag is '
-                                'set to true. Otherwise, skip evaluation.'))
+      name='skip_eval', default=False,
+      help=flags_core.help_wrap('Skip evaluation when this flag is true'))
 
   choice_kwargs = dict(
       name='resnet_size', short_name='rs', default='50',

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -523,8 +523,8 @@ def resnet_main(
         num_epochs=1,
         dtype=flags_core.get_tf_dtype(flags_obj))
 
-  if flags_obj.eval_only or not flags_obj.train_epochs:
-    # If --eval_only is set, perform a single loop with zero train epochs.
+  if not flags_obj.train_epochs:
+    # If train_epoches is not set, perform a single loop with zero train epochs.
     schedule, n_loops = [0], 1
   else:
     # Compute the number of times to loop while training. All but the last
@@ -546,22 +546,23 @@ def resnet_main(
       classifier.train(input_fn=lambda: input_fn_train(num_train_epochs),
                        hooks=train_hooks, max_steps=flags_obj.max_train_steps)
 
-    tf.logging.info('Starting to evaluate.')
+    if flags_obj.do_eval:
+      tf.logging.info('Starting to evaluate.')
 
-    # flags_obj.max_train_steps is generally associated with testing and
-    # profiling. As a result it is frequently called with synthetic data, which
-    # will iterate forever. Passing steps=flags_obj.max_train_steps allows the
-    # eval (which is generally unimportant in those circumstances) to terminate.
-    # Note that eval will run for max_train_steps each loop, regardless of the
-    # global_step count.
-    eval_results = classifier.evaluate(input_fn=input_fn_eval,
-                                       steps=flags_obj.max_train_steps)
+      # flags_obj.max_train_steps is generally associated with testing and
+      # profiling. As a result it is frequently called with synthetic data,
+      # which will iterate forever. Passing steps=flags_obj.max_train_steps
+      # allows the eval (which is generally unimportant in those circumstances)
+      # to terminate. Note that eval will run for max_train_steps each loop,
+      # regardless of the global_step count.
+      eval_results = classifier.evaluate(input_fn=input_fn_eval,
+                                         steps=flags_obj.max_train_steps)
 
-    benchmark_logger.log_evaluation_result(eval_results)
+      benchmark_logger.log_evaluation_result(eval_results)
 
-    if model_helpers.past_stop_threshold(
-        flags_obj.stop_threshold, eval_results['accuracy']):
-      break
+      if model_helpers.past_stop_threshold(
+          flags_obj.stop_threshold, eval_results['accuracy']):
+        break
 
   if flags_obj.export_dir is not None:
     # Exports a saved model for the given classifier.
@@ -594,9 +595,9 @@ def define_resnet_flags(resnet_size_choices=None):
           'If not None initialize all the network except the final layer with '
           'these values'))
   flags.DEFINE_boolean(
-      name='eval_only', default=False,
-      help=flags_core.help_wrap('Skip training and only perform evaluation on '
-                                'the latest checkpoint.'))
+      name='do_eval', default=False,
+      help=flags_core.help_wrap('Do evalueation step only when this flag is '
+                                'set to true. Otherwise, skip evaluation.'))
 
   choice_kwargs = dict(
       name='resnet_size', short_name='rs', default='50',


### PR DESCRIPTION
...by changing the flag "eval_only" to "skip_eval". It is still possible to do eval only, by setting the training epoch to 0, and skip eval to false. 
This way, it is possible to do both training only and evaluation only. 